### PR TITLE
Bugfix for PHP 7.4 warning:

### DIFF
--- a/src/RrdCachedClient.php
+++ b/src/RrdCachedClient.php
@@ -360,7 +360,7 @@ class RrdCachedClient
 
                 case 'create':
                     if (0 < strpos($v, 'File exists')) {
-                        continue;
+                        continue 2;
                     }
 
                     throw new RrdCachedException('Error create file '.$batchItem['fileName']);


### PR DESCRIPTION
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ..../vendor/mitinsany/rrdcached-php/src/RrdCachedClient.php on line 363